### PR TITLE
Fix Portuguese typo in dashboard

### DIFF
--- a/sales_dashboard/modules/clients.py
+++ b/sales_dashboard/modules/clients.py
@@ -63,7 +63,7 @@ def display_clients_advanced(df_filtered,df):
         st.plotly_chart(fig_card, use_container_width=True)
 
     with col2:
-        st.markdown("### Destribuição por motivo de compra")
+        st.markdown("### Distribuição por motivo de compra")
         reason_counts = (
             df_clients.fillna("unknown")
             .groupby("SALES_REASON_NAME")


### PR DESCRIPTION
## Summary
- correct a typo in clients dashboard module

## Testing
- `git log -1 -p`

------
https://chatgpt.com/codex/tasks/task_e_687519bc0b608330b64754155fac1421